### PR TITLE
spell_proc_event - incorrect # of fields handled by core

### DIFF
--- a/src/game/DBCEnums.h
+++ b/src/game/DBCEnums.h
@@ -559,36 +559,10 @@ enum SpellEffectIndex
 {
     EFFECT_INDEX_0     = 0,
     EFFECT_INDEX_1     = 1,
-    EFFECT_INDEX_2     = 2,
-    EFFECT_INDEX_3     = 3,
-    EFFECT_INDEX_4     = 4,
-    EFFECT_INDEX_5     = 5,
-    EFFECT_INDEX_6     = 6,
-    EFFECT_INDEX_7     = 7,
-    EFFECT_INDEX_8     = 8,
-    EFFECT_INDEX_9     = 9,
-    EFFECT_INDEX_10    = 10,
-    EFFECT_INDEX_11    = 11,
-    EFFECT_INDEX_12    = 12,
-    EFFECT_INDEX_13    = 13,
-    EFFECT_INDEX_14    = 14,
-    EFFECT_INDEX_15    = 15,
-    EFFECT_INDEX_16    = 16,
-    EFFECT_INDEX_17    = 17,
-    EFFECT_INDEX_18    = 18,
-    EFFECT_INDEX_19    = 19,
-    EFFECT_INDEX_20    = 20,
+    EFFECT_INDEX_2     = 2
 };
 
-#define EFFECT_MASK_ALL \
-    ((1 << EFFECT_INDEX_0) | (1 << EFFECT_INDEX_1) | (1 << EFFECT_INDEX_2) | \
-    (1 << EFFECT_INDEX_3) | (1 << EFFECT_INDEX_4) | (1 << EFFECT_INDEX_5) | \
-    (1 << EFFECT_INDEX_6) | (1 << EFFECT_INDEX_7) | (1 << EFFECT_INDEX_8) | \
-    (1 << EFFECT_INDEX_9) | (1 << EFFECT_INDEX_10) | (1 << EFFECT_INDEX_11) | \
-    (1 << EFFECT_INDEX_12) | (1 << EFFECT_INDEX_13) | (1 << EFFECT_INDEX_14) | \
-    (1 << EFFECT_INDEX_15) | (1 << EFFECT_INDEX_16) | (1 << EFFECT_INDEX_17) | \
-    (1 << EFFECT_INDEX_18) | (1 << EFFECT_INDEX_19) | (1 << EFFECT_INDEX_20))
-#define MAX_EFFECT_INDEX 21
+#define MAX_EFFECT_INDEX 3
 
 enum SpellFamily
 {

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -504,9 +504,8 @@ void Spell::FillTargetMap()
     // TODO: ADD the correct target FILLS!!!!!!
 
     UnitList tmpUnitLists[MAX_EFFECT_INDEX];                // Stores the temporary Target Lists for each effect
-    uint8 effToIndex[MAX_EFFECT_INDEX] = { 0, 1, 2, 3, 4, 5, 6,
-                                           7, 8, 9, 10, 11, 12, 13,
-                                           14, 15, 16, 17, 18, 19, 20 };    // Helper array, to link to another tmpUnitList, if the targets for both effects match
+    uint8 effToIndex[MAX_EFFECT_INDEX] = {0, 1, 2};    // Helper array, to link to another tmpUnitList, if the targets for both effects match
+    
     for (int i = 0; i < MAX_EFFECT_INDEX; ++i)
     {
         SpellEffectEntry const* spellEffect = m_spellInfo->GetSpellEffect(SpellEffectIndex(i));

--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -1420,43 +1420,7 @@ void SpellMgr::LoadSpellProcEvents()
                                             "SpellFamilyMaskB0, SpellFamilyMaskB1, SpellFamilyMaskB2, "
     //                                       9                  10                 11
                                             "SpellFamilyMaskC0, SpellFamilyMaskC1, SpellFamilyMaskC2, "
-    //                                       12                 13                 14
-                                            "SpellFamilyMaskD0, SpellFamilyMaskD1, SpellFamilyMaskD2, "
-    //                                       15                 16                 17
-                                            "SpellFamilyMaskE0, SpellFamilyMaskE1, SpellFamilyMaskE2, "
-    //                                       18                 19                 20
-                                            "SpellFamilyMaskF0, SpellFamilyMaskF1, SpellFamilyMaskF2, "
-    //                                       21                 22                 23
-                                            "SpellFamilyMaskG0, SpellFamilyMaskG1, SpellFamilyMaskG2, "
-    //                                       24                 25                 26
-                                            "SpellFamilyMaskH0, SpellFamilyMaskH1, SpellFamilyMaskH2, "
-    //                                       27                 28                 29
-                                            "SpellFamilyMaskI0, SpellFamilyMaskI1, SpellFamilyMaskI2, "
-    //                                       30                 31                 32
-                                            "SpellFamilyMaskJ0, SpellFamilyMaskJ1, SpellFamilyMaskJ2, "
-    //                                       33                 34                 35
-                                            "SpellFamilyMaskK0, SpellFamilyMaskK1, SpellFamilyMaskK2, "
-    //                                       36                 37                 38
-                                            "SpellFamilyMaskL0, SpellFamilyMaskL1, SpellFamilyMaskL2, "
-    //                                       39                 40                 41
-                                            "SpellFamilyMaskM0, SpellFamilyMaskM1, SpellFamilyMaskM2, "
-    //                                       42                 43                 44
-                                            "SpellFamilyMaskN0, SpellFamilyMaskN1, SpellFamilyMaskN2, "
-    //                                       45                 46                 47
-                                            "SpellFamilyMaskO0, SpellFamilyMaskO1, SpellFamilyMaskO2, "
-    //                                       48                 49                 50
-                                            "SpellFamilyMaskP0, SpellFamilyMaskP1, SpellFamilyMaskP2, "
-    //                                       51                 52                 53
-                                            "SpellFamilyMaskQ0, SpellFamilyMaskQ1, SpellFamilyMaskQ2, "
-    //                                       54                 55                 56
-                                            "SpellFamilyMaskR0, SpellFamilyMaskR1, SpellFamilyMaskR2, "
-    //                                       57                 58                 59
-                                            "SpellFamilyMaskS0, SpellFamilyMaskS1, SpellFamilyMaskS2, "
-    //                                       60                 61                 62
-                                            "SpellFamilyMaskT0, SpellFamilyMaskT1, SpellFamilyMaskT2, "
-    //                                       63                 64                 65
-                                            "SpellFamilyMaskU0, SpellFamilyMaskU1, SpellFamilyMaskU2, "
-    //                                       66         67      68       69            70
+    //                                       12         13      14       15            16
                                             "procFlags, procEx, ppmRate, CustomChance, Cooldown FROM spell_proc_event");
     if (!result)
     {
@@ -1489,11 +1453,11 @@ void SpellMgr::LoadSpellProcEvents()
                                          (uint64)fields[i + 3].GetUInt32() | ((uint64)fields[i + 6].GetUInt32() << 32),
                                          fields[i + 9].GetUInt32());
         }
-        spe.procFlags       = fields[66].GetUInt32();
-        spe.procEx          = fields[67].GetUInt32();
-        spe.ppmRate         = fields[68].GetFloat();
-        spe.customChance    = fields[69].GetFloat();
-        spe.cooldown        = fields[70].GetUInt32();
+        spe.procFlags       = fields[12].GetUInt32();
+        spe.procEx          = fields[13].GetUInt32();
+        spe.ppmRate         = fields[14].GetFloat();
+        spe.customChance    = fields[15].GetFloat();
+        spe.cooldown        = fields[16].GetUInt32();
 
         rankHelper.RecordRank(spe, entry);
     }

--- a/src/game/SpellMgr.h
+++ b/src/game/SpellMgr.h
@@ -142,7 +142,7 @@ inline bool IsAuraApplyEffect(SpellEntry const* spellInfo, SpellEffectIndex effe
     return false;
 }
 
-inline bool IsSpellAppliesAura(SpellEntry const* spellInfo, uint32 effectMask = EFFECT_MASK_ALL)
+inline bool IsSpellAppliesAura(SpellEntry const* spellInfo, uint32 effectMask = ((1 << EFFECT_INDEX_0) | (1 << EFFECT_INDEX_1) | (1 << EFFECT_INDEX_2)))
 {
     for (int i = 0; i < MAX_EFFECT_INDEX; ++i)
         if (effectMask & (1 << i))
@@ -189,7 +189,7 @@ inline bool IsPeriodicRegenerateEffect(SpellEntry const* spellInfo, SpellEffectI
 
 bool IsCastEndProcModifierAura(SpellEntry const* spellInfo, SpellEffectIndex effecIdx, SpellEntry const* procSpell);
 
-inline bool IsSpellHaveAura(SpellEntry const* spellInfo, AuraType aura, uint32 effectMask = EFFECT_MASK_ALL)
+inline bool IsSpellHaveAura(SpellEntry const* spellInfo, AuraType aura, uint32 effectMask = ((1 << EFFECT_INDEX_0) | (1 << EFFECT_INDEX_1) | (1 << EFFECT_INDEX_2)))
 {
     for (int i = 0; i < MAX_EFFECT_INDEX; ++i)
         if (effectMask & (1 << i))

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -679,9 +679,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit* pVictim, uint32 damage, Aura
     // some dummy spells have trigger spell in spell data already (from 3.0.3)
     uint32 triggered_spell_id = dummySpellEffect->EffectApplyAuraName == SPELL_AURA_DUMMY ? dummySpellEffect->EffectTriggerSpell : 0;
     Unit* target = pVictim;
-    int32  basepoints[MAX_EFFECT_INDEX] = {0, 0, 0, 0, 0, 0, 0,
-                                           0, 0, 0, 0, 0, 0, 0,
-                                           0, 0, 0, 0, 0, 0, 0};
+    int32  basepoints[MAX_EFFECT_INDEX] = {0, 0, 0};
 
     switch(dummySpell->GetSpellFamilyName())
     {
@@ -2919,9 +2917,7 @@ SpellAuraProcResult Unit::HandleProcTriggerSpellAuraProc(Unit* pVictim, uint32 d
     SpellEffectEntry const* spellEffect = auraSpellInfo->GetSpellEffect(triggeredByAura->GetEffIndex());
     uint32 trigger_spell_id = spellEffect ? spellEffect->EffectTriggerSpell : 0;
     Unit*  target = NULL;
-    int32  basepoints[MAX_EFFECT_INDEX] = {0, 0, 0, 0, 0, 0, 0,
-                                           0, 0, 0, 0, 0, 0, 0,
-                                           0, 0, 0, 0, 0, 0, 0};
+    int32  basepoints[MAX_EFFECT_INDEX] = {0, 0, 0};
 
     if (triggeredByAura->GetModifier()->m_auraname == SPELL_AURA_PROC_TRIGGER_SPELL_WITH_VALUE)
         basepoints[0] = triggerAmount;


### PR DESCRIPTION
Re the CATA database (which Four uses), the server core was not handling
the data from the table correctly; it was set up to handle more fields
than the table has.

extra info: Looking at Zero and One, the table's fields have been
reduced further.
